### PR TITLE
rename as db_connect, db_disconnect on backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ You need latest [Julia 0.7 DEV](https://julialang.org/downloads/nightlies.html).
 ```julia
 using Pkg
 Pkg.clone("https://github.com/wookay/Octo.jl.git")
+
+# requires master
+Pkg.checkout("DataStreams", "master")
 ```
 
 

--- a/src/Backends/JDBC.jl
+++ b/src/Backends/JDBC.jl
@@ -9,12 +9,12 @@ import Octo.Backends: UnsupportedError
 function sink(::Type)
 end
 
-# connect
-function connect(; kwargs...)
+# db_connect
+function db_connect(; kwargs...)
 end
 
-# disconnect
-function disconnect()
+# db_disconnect
+function db_disconnect()
 end
 
 # query

--- a/src/Backends/MySQL.jl
+++ b/src/Backends/MySQL.jl
@@ -18,8 +18,8 @@ function sink(T::Type)
    current[:sink] = T
 end
 
-# connect
-function connect(; kwargs...)
+# db_connect
+function db_connect(; kwargs...)
     args = (:hostname, :username, :password)
     (hostname, username, password) = getindex.(Ref(kwargs), args)
     options = filter(kv -> !(kv.first in args), kwargs)
@@ -27,8 +27,8 @@ function connect(; kwargs...)
     current[:conn] = conn
 end
 
-# disconnect
-function disconnect()
+# db_disconnect
+function db_disconnect()
     conn = current_conn()
     MySQL.disconnect(conn)
     current[:conn] = nothing

--- a/src/Backends/ODBC.jl
+++ b/src/Backends/ODBC.jl
@@ -18,8 +18,8 @@ function sink(::Type)
     current[:sink] = T
 end
 
-# connect
-function connect(; kwargs...)
+# db_connect
+function db_connect(; kwargs...)
     if !isempty(kwargs)
         args = (:username, :password)
         username = get(kwargs, :username, "")
@@ -31,8 +31,8 @@ function connect(; kwargs...)
     end 
 end
 
-# disconnect
-function disconnect()
+# db_disconnect
+function db_disconnect()
     dsn = current_dsn()
     ODBC.disconnect!(dsn)
     current[:dsn] = nothing

--- a/src/Backends/PostgreSQL.jl
+++ b/src/Backends/PostgreSQL.jl
@@ -17,8 +17,8 @@ function sink(T::Type)
    current[:sink] = T
 end
 
-# connect
-function connect(; kwargs...)
+# db_connect
+function db_connect(; kwargs...)
     if !isempty(kwargs)
         str = join(map(kv->join(kv, '='), collect(kwargs)), ' ')
         conn = LibPQ.Connection(str)
@@ -26,8 +26,8 @@ function connect(; kwargs...)
     end
 end
 
-# disconnect
-function disconnect()
+# db_disconnect
+function db_disconnect()
     conn = current_conn()
     close(conn)
     current[:conn] = nothing

--- a/src/Backends/SQL.jl
+++ b/src/Backends/SQL.jl
@@ -6,12 +6,12 @@ import Octo.Repo: ExecuteResult
 function sink(::Type)
 end
 
-# connect
-function connect(; kwargs...)
+# db_connect
+function db_connect(; kwargs...)
 end
 
-# disconnect
-function disconnect()
+# db_disconnect
+function db_disconnect()
 end
 
 # query

--- a/src/Backends/SQLite.jl
+++ b/src/Backends/SQLite.jl
@@ -16,15 +16,15 @@ function sink(T::Type)
    current[:sink] = T
 end
 
-# connect
-function connect(; kwargs...)
+# db_connect
+function db_connect(; kwargs...)
     database = getindex(kwargs, :database)
     db = SQLite.DB(database)
     current[:db] = db
 end
 
-# disconnect
-function disconnect()
+# db_disconnect
+function db_disconnect()
     current[:db] = nothing
 end
 

--- a/src/Repo.jl
+++ b/src/Repo.jl
@@ -83,7 +83,7 @@ function connect(; adapter::Module, kwargs...)
     args = (:sink,)
     options = filter(kv -> !(kv.first in args), kwargs)
 
-    Base.invokelatest(loader.connect; options...)
+    Base.invokelatest(loader.db_connect; options...)
 end
 
 # Repo.disconnect
@@ -92,7 +92,7 @@ end
 """
 function disconnect()
     loader = current_loader()
-    disconnected = loader.disconnect()
+    disconnected = loader.db_disconnect()
     current[:adapter] = nothing
     current[:loader] = nothing
     disconnected


### PR DESCRIPTION
Fix https://github.com/wookay/Octo.jl/issues/3

to make a distinction,
rename it as `db_connect`, `db_disconnect` on backends.